### PR TITLE
Main part for the fix of https://github.com/tempesta-tech/tempesta/issues/1170

### DIFF
--- a/crypto/aead.c
+++ b/crypto/aead.c
@@ -343,6 +343,22 @@ struct crypto_aead *crypto_alloc_aead(const char *alg_name, u32 type, u32 mask)
 }
 EXPORT_SYMBOL_GPL(crypto_alloc_aead);
 
+#ifdef CONFIG_SECURITY_TEMPESTA
+struct crypto_alg *
+crypto_find_aead(const char *alg_name, u32 type, u32 mask)
+{
+	return crypto_find_alg(alg_name, &crypto_aead_type, type, mask);
+}
+EXPORT_SYMBOL_GPL(crypto_find_aead);
+
+struct crypto_aead *
+crypto_alloc_aead_atomic(struct crypto_alg *alg)
+{
+	return crypto_create_tfm(alg, &crypto_aead_type);
+}
+EXPORT_SYMBOL_GPL(crypto_alloc_aead_atomic);
+#endif
+
 static int aead_prepare_alg(struct aead_alg *alg)
 {
 	struct crypto_alg *base = &alg->base;

--- a/crypto/ahash.c
+++ b/crypto/ahash.c
@@ -559,6 +559,23 @@ struct crypto_ahash *crypto_alloc_ahash(const char *alg_name, u32 type,
 }
 EXPORT_SYMBOL_GPL(crypto_alloc_ahash);
 
+#ifdef CONFIG_SECURITY_TEMPESTA
+/* Asynch hash is required by GHASH used in GCM. */
+struct crypto_alg *
+crypto_find_ahash(const char *alg_name, u32 type, u32 mask)
+{
+	return crypto_find_alg(alg_name, &crypto_ahash_type, type, mask);
+}
+EXPORT_SYMBOL_GPL(crypto_find_ahash);
+
+struct crypto_ahash *
+crypto_alloc_ahash_atomic(struct crypto_alg *alg)
+{
+	return crypto_create_tfm(alg, &crypto_ahash_type);
+}
+EXPORT_SYMBOL_GPL(crypto_alloc_ahash_atomic);
+#endif
+
 int crypto_has_ahash(const char *alg_name, u32 type, u32 mask)
 {
 	return crypto_type_has_alg(alg_name, &crypto_ahash_type, type, mask);

--- a/crypto/api.c
+++ b/crypto/api.c
@@ -491,6 +491,9 @@ struct crypto_alg *crypto_find_alg(const char *alg_name,
 	struct crypto_alg *(*lookup)(const char *name, u32 type, u32 mask) =
 		crypto_alg_mod_lookup;
 
+	/* The function is slow and preemptable to be called in softirq. */
+	WARN_ON_ONCE(in_serving_softirq());
+
 	if (frontend) {
 		type &= frontend->maskclear;
 		mask &= frontend->maskclear;

--- a/crypto/cryptd.c
+++ b/crypto/cryptd.c
@@ -1217,12 +1217,29 @@ struct cryptd_skcipher *cryptd_alloc_skcipher(const char *alg_name,
 	char cryptd_alg_name[CRYPTO_MAX_ALG_NAME];
 	struct cryptd_skcipher_ctx *ctx;
 	struct crypto_skcipher *tfm;
+#ifdef CONFIG_SECURITY_TEMPESTA
+	static struct crypto_alg *alg = NULL;
 
+	if (unlikely(!alg)) {
+		WARN_ON_ONCE(in_serving_softirq());
+		if (snprintf(cryptd_alg_name, CRYPTO_MAX_ALG_NAME, "cryptd(%s)",
+			     alg_name)
+		    >= CRYPTO_MAX_ALG_NAME)
+		{
+			return ERR_PTR(-EINVAL);
+		}
+		alg = crypto_find_skcipher(cryptd_alg_name, type, mask);
+		if (IS_ERR(alg))
+			return (struct cryptd_skcipher *)alg;
+	}
+	tfm = crypto_alloc_skcipher_atomic(alg);
+#else
 	if (snprintf(cryptd_alg_name, CRYPTO_MAX_ALG_NAME,
 		     "cryptd(%s)", alg_name) >= CRYPTO_MAX_ALG_NAME)
 		return ERR_PTR(-EINVAL);
 
 	tfm = crypto_alloc_skcipher(cryptd_alg_name, type, mask);
+#endif
 	if (IS_ERR(tfm))
 		return ERR_CAST(tfm);
 
@@ -1269,11 +1286,28 @@ struct cryptd_ahash *cryptd_alloc_ahash(const char *alg_name,
 	char cryptd_alg_name[CRYPTO_MAX_ALG_NAME];
 	struct cryptd_hash_ctx *ctx;
 	struct crypto_ahash *tfm;
+#ifdef CONFIG_SECURITY_TEMPESTA
+	static struct crypto_alg *alg = NULL;
 
+	if (unlikely(!alg)) {
+		WARN_ON_ONCE(in_serving_softirq());
+		if (snprintf(cryptd_alg_name, CRYPTO_MAX_ALG_NAME, "cryptd(%s)",
+			     alg_name)
+		    >= CRYPTO_MAX_ALG_NAME)
+		{
+			return ERR_PTR(-EINVAL);
+		}
+		alg = crypto_find_ahash(cryptd_alg_name, type, mask);
+		if (IS_ERR(alg))
+			return (struct cryptd_ahash *)alg;
+	}
+	tfm = crypto_alloc_ahash_atomic(alg);
+#else
 	if (snprintf(cryptd_alg_name, CRYPTO_MAX_ALG_NAME,
 		     "cryptd(%s)", alg_name) >= CRYPTO_MAX_ALG_NAME)
 		return ERR_PTR(-EINVAL);
 	tfm = crypto_alloc_ahash(cryptd_alg_name, type, mask);
+#endif
 	if (IS_ERR(tfm))
 		return ERR_CAST(tfm);
 	if (tfm->base.__crt_alg->cra_module != THIS_MODULE) {
@@ -1326,11 +1360,28 @@ struct cryptd_aead *cryptd_alloc_aead(const char *alg_name,
 	char cryptd_alg_name[CRYPTO_MAX_ALG_NAME];
 	struct cryptd_aead_ctx *ctx;
 	struct crypto_aead *tfm;
+#ifdef CONFIG_SECURITY_TEMPESTA
+	static struct crypto_alg *alg = NULL;
 
+	if (unlikely(!alg)) {
+		WARN_ON_ONCE(in_serving_softirq());
+		if (snprintf(cryptd_alg_name, CRYPTO_MAX_ALG_NAME, "cryptd(%s)",
+			     alg_name)
+		    >= CRYPTO_MAX_ALG_NAME)
+		{
+			return ERR_PTR(-EINVAL);
+		}
+		alg = crypto_find_aead(cryptd_alg_name, type, mask);
+		if (IS_ERR(alg))
+			return (struct cryptd_aead *)alg;
+	}
+	tfm = crypto_alloc_aead_atomic(alg);
+#else
 	if (snprintf(cryptd_alg_name, CRYPTO_MAX_ALG_NAME,
 		     "cryptd(%s)", alg_name) >= CRYPTO_MAX_ALG_NAME)
 		return ERR_PTR(-EINVAL);
 	tfm = crypto_alloc_aead(cryptd_alg_name, type, mask);
+#endif
 	if (IS_ERR(tfm))
 		return ERR_CAST(tfm);
 	if (tfm->base.__crt_alg->cra_module != THIS_MODULE) {

--- a/crypto/shash.c
+++ b/crypto/shash.c
@@ -454,6 +454,22 @@ struct crypto_shash *crypto_alloc_shash(const char *alg_name, u32 type,
 }
 EXPORT_SYMBOL_GPL(crypto_alloc_shash);
 
+#ifdef CONFIG_SECURITY_TEMPESTA
+struct crypto_alg *
+crypto_find_shash(const char *alg_name, u32 type, u32 mask)
+{
+	return crypto_find_alg(alg_name, &crypto_shash_type, type, mask);
+}
+EXPORT_SYMBOL_GPL(crypto_find_shash);
+
+struct crypto_shash *
+crypto_alloc_shash_atomic(struct crypto_alg *alg)
+{
+	return crypto_create_tfm(alg, &crypto_shash_type);
+}
+EXPORT_SYMBOL_GPL(crypto_alloc_shash_atomic);
+#endif
+
 static int shash_prepare_alg(struct shash_alg *alg)
 {
 	struct crypto_alg *base = &alg->base;

--- a/crypto/skcipher.c
+++ b/crypto/skcipher.c
@@ -928,6 +928,22 @@ struct crypto_skcipher *crypto_alloc_skcipher(const char *alg_name,
 }
 EXPORT_SYMBOL_GPL(crypto_alloc_skcipher);
 
+#ifdef CONFIG_SECURITY_TEMPESTA
+struct crypto_alg *
+crypto_find_skcipher(const char *alg_name, u32 type, u32 mask)
+{
+	return crypto_find_alg(alg_name, &crypto_skcipher_type2, type, mask);
+}
+EXPORT_SYMBOL_GPL(crypto_find_skcipher);
+
+struct crypto_skcipher *
+crypto_alloc_skcipher_atomic(struct crypto_alg *alg)
+{
+	return crypto_create_tfm(alg, &crypto_skcipher_type2);
+}
+EXPORT_SYMBOL_GPL(crypto_alloc_skcipher_atomic);
+#endif
+
 int crypto_has_skcipher2(const char *alg_name, u32 type, u32 mask)
 {
 	return crypto_type_has_alg(alg_name, &crypto_skcipher_type2,

--- a/include/crypto/aead.h
+++ b/include/crypto/aead.h
@@ -179,6 +179,11 @@ static inline struct crypto_aead *__crypto_aead_cast(struct crypto_tfm *tfm)
  */
 struct crypto_aead *crypto_alloc_aead(const char *alg_name, u32 type, u32 mask);
 
+#ifdef CONFIG_SECURITY_TEMPESTA
+struct crypto_alg *crypto_find_aead(const char *alg_name, u32 type, u32 mask);
+struct crypto_aead *crypto_alloc_aead_atomic(struct crypto_alg *alg);
+#endif
+
 static inline struct crypto_tfm *crypto_aead_tfm(struct crypto_aead *tfm)
 {
 	return &tfm->base;

--- a/include/crypto/hash.h
+++ b/include/crypto/hash.h
@@ -245,6 +245,11 @@ static inline struct crypto_ahash *__crypto_ahash_cast(struct crypto_tfm *tfm)
 struct crypto_ahash *crypto_alloc_ahash(const char *alg_name, u32 type,
 					u32 mask);
 
+#ifdef CONFIG_SECURITY_TEMPESTA
+struct crypto_alg *crypto_find_ahash(const char *alg_name, u32 type, u32 mask);
+struct crypto_ahash *crypto_alloc_ahash_atomic(struct crypto_alg *alg);
+#endif
+
 static inline struct crypto_tfm *crypto_ahash_tfm(struct crypto_ahash *tfm)
 {
 	return &tfm->base;
@@ -680,6 +685,11 @@ static inline void ahash_request_set_crypt(struct ahash_request *req,
  */
 struct crypto_shash *crypto_alloc_shash(const char *alg_name, u32 type,
 					u32 mask);
+
+#ifdef CONFIG_SECURITY_TEMPESTA
+struct crypto_alg *crypto_find_shash(const char *alg_name, u32 type, u32 mask);
+struct crypto_shash *crypto_alloc_shash_atomic(struct crypto_alg *alg);
+#endif
 
 static inline struct crypto_tfm *crypto_shash_tfm(struct crypto_shash *tfm)
 {

--- a/include/crypto/skcipher.h
+++ b/include/crypto/skcipher.h
@@ -197,6 +197,12 @@ static inline struct crypto_skcipher *__crypto_skcipher_cast(
 struct crypto_skcipher *crypto_alloc_skcipher(const char *alg_name,
 					      u32 type, u32 mask);
 
+#ifdef CONFIG_SECURITY_TEMPESTA
+struct crypto_alg *crypto_find_skcipher(const char *alg_name, u32 type,
+					u32 mask);
+struct crypto_skcipher *crypto_alloc_skcipher_atomic(struct crypto_alg *alg);
+#endif
+
 static inline struct crypto_tfm *crypto_skcipher_tfm(
 	struct crypto_skcipher *tfm)
 {


### PR DESCRIPTION
Split crypto_alloc_tfm() into crypto_find_*() sleepable part and atomic, suitable for calling from softirq, crypto_alloc_*_atomic(). Previously crypto_find_alg() called moules loading and used semaphore synchronization, so we had softlockups in TLS handshakes.
