### PR TITLE
cache multiple algorithms, discern by names and flags

### DIFF
--- a/crypto/aead.c
+++ b/crypto/aead.c
@@ -354,6 +354,8 @@ EXPORT_SYMBOL_GPL(crypto_find_aead);
 struct crypto_aead *
 crypto_alloc_aead_atomic(struct crypto_alg *alg)
 {
+	alg = crypto_mod_get(alg);
+	BUG_ON(!alg);
 	return crypto_create_tfm(alg, &crypto_aead_type);
 }
 EXPORT_SYMBOL_GPL(crypto_alloc_aead_atomic);

--- a/crypto/ahash.c
+++ b/crypto/ahash.c
@@ -571,6 +571,8 @@ EXPORT_SYMBOL_GPL(crypto_find_ahash);
 struct crypto_ahash *
 crypto_alloc_ahash_atomic(struct crypto_alg *alg)
 {
+	alg = crypto_mod_get(alg);
+	BUG_ON(!alg);
 	return crypto_create_tfm(alg, &crypto_ahash_type);
 }
 EXPORT_SYMBOL_GPL(crypto_alloc_ahash_atomic);

--- a/crypto/cryptd.c
+++ b/crypto/cryptd.c
@@ -32,6 +32,8 @@
 #include <linux/sched.h>
 #include <linux/slab.h>
 
+#include "internal.h"
+
 #define CRYPTD_MAX_CPU_QLEN 1000
 
 struct cryptd_cpu_queue {
@@ -1211,33 +1213,98 @@ void cryptd_free_ablkcipher(struct cryptd_ablkcipher *tfm)
 }
 EXPORT_SYMBOL_GPL(cryptd_free_ablkcipher);
 
+#ifdef CONFIG_SECURITY_TEMPESTA
+
+#define MAX_CACHED_ALG_COUNT	8
+struct alg_cache {
+	int n;
+	spinlock_t lock;
+	struct {
+		u32 type;
+		u32 mask;
+		struct crypto_alg *alg;
+		char alg_name[CRYPTO_MAX_ALG_NAME];
+	} a[MAX_CACHED_ALG_COUNT];
+};
+
+static struct alg_cache skcipher_alg_cache;
+static struct alg_cache ahash_alg_cache;
+static struct alg_cache aead_alg_cache;
+
+/*
+ * Finds a previously allocated algorithm or allocates a new one. In any case,
+ * returned alg holds at least one reference to its module.
+ */
+static struct crypto_alg *
+cryptd_find_alg_cached(const char *cryptd_alg_name, u32 type, u32 mask,
+		       struct crypto_alg *(*find_alg)(const char *, u32, u32),
+		       struct alg_cache *__restrict ac)
+{
+	struct crypto_alg *alg;
+	int k;
+
+	spin_lock(&ac->lock);
+	for (k = 0; k < ac->n; k++) {
+		if (strcmp(ac->a[k].alg_name, cryptd_alg_name) == 0
+		    && ac->a[k].type == type && ac->a[k].mask == mask)
+		{
+			spin_unlock(&ac->lock);
+			return ac->a[k].alg;
+		}
+	}
+	spin_unlock(&ac->lock);
+
+	/* Searching for the algorithm may sleep, so warn about it. */
+	WARN_ON_ONCE(in_serving_softirq());
+
+	alg = find_alg(cryptd_alg_name, type, mask);
+	if (IS_ERR(alg))
+		return alg;
+
+	spin_lock(&ac->lock);
+	if (ac->n >= MAX_CACHED_ALG_COUNT) {
+		spin_unlock(&ac->lock);
+		BUG();
+		return ERR_PTR(-ENOMEM);
+	}
+
+	snprintf(ac->a[ac->n].alg_name, sizeof(ac->a[ac->n].alg_name), "%s",
+		 cryptd_alg_name);
+
+	ac->a[ac->n].type = type;
+	ac->a[ac->n].mask = mask;
+	ac->a[ac->n].alg = alg;
+
+	ac->n += 1;
+	spin_unlock(&ac->lock);
+
+	return alg;
+}
+#endif /* CONFIG_SECURITY_TEMPESTA */
+
 struct cryptd_skcipher *cryptd_alloc_skcipher(const char *alg_name,
 					      u32 type, u32 mask)
 {
 	char cryptd_alg_name[CRYPTO_MAX_ALG_NAME];
 	struct cryptd_skcipher_ctx *ctx;
 	struct crypto_skcipher *tfm;
-#ifdef CONFIG_SECURITY_TEMPESTA
-	static struct crypto_alg *alg = NULL;
 
-	if (unlikely(!alg)) {
-		WARN_ON_ONCE(in_serving_softirq());
-		if (snprintf(cryptd_alg_name, CRYPTO_MAX_ALG_NAME, "cryptd(%s)",
-			     alg_name)
-		    >= CRYPTO_MAX_ALG_NAME)
-		{
-			return ERR_PTR(-EINVAL);
-		}
-		alg = crypto_find_skcipher(cryptd_alg_name, type, mask);
-		if (IS_ERR(alg))
-			return (struct cryptd_skcipher *)alg;
-	}
-	tfm = crypto_alloc_skcipher_atomic(alg);
-#else
 	if (snprintf(cryptd_alg_name, CRYPTO_MAX_ALG_NAME,
 		     "cryptd(%s)", alg_name) >= CRYPTO_MAX_ALG_NAME)
 		return ERR_PTR(-EINVAL);
 
+#ifdef CONFIG_SECURITY_TEMPESTA
+	{
+		struct crypto_alg *alg =
+			cryptd_find_alg_cached(cryptd_alg_name, type, mask,
+					       crypto_find_skcipher,
+					       &skcipher_alg_cache);
+		if (IS_ERR(alg))
+			return (struct cryptd_skcipher *)alg;
+
+		tfm = crypto_alloc_skcipher_atomic(alg);
+	}
+#else
 	tfm = crypto_alloc_skcipher(cryptd_alg_name, type, mask);
 #endif
 	if (IS_ERR(tfm))
@@ -1286,26 +1353,23 @@ struct cryptd_ahash *cryptd_alloc_ahash(const char *alg_name,
 	char cryptd_alg_name[CRYPTO_MAX_ALG_NAME];
 	struct cryptd_hash_ctx *ctx;
 	struct crypto_ahash *tfm;
-#ifdef CONFIG_SECURITY_TEMPESTA
-	static struct crypto_alg *alg = NULL;
 
-	if (unlikely(!alg)) {
-		WARN_ON_ONCE(in_serving_softirq());
-		if (snprintf(cryptd_alg_name, CRYPTO_MAX_ALG_NAME, "cryptd(%s)",
-			     alg_name)
-		    >= CRYPTO_MAX_ALG_NAME)
-		{
-			return ERR_PTR(-EINVAL);
-		}
-		alg = crypto_find_ahash(cryptd_alg_name, type, mask);
-		if (IS_ERR(alg))
-			return (struct cryptd_ahash *)alg;
-	}
-	tfm = crypto_alloc_ahash_atomic(alg);
-#else
 	if (snprintf(cryptd_alg_name, CRYPTO_MAX_ALG_NAME,
 		     "cryptd(%s)", alg_name) >= CRYPTO_MAX_ALG_NAME)
 		return ERR_PTR(-EINVAL);
+
+#ifdef CONFIG_SECURITY_TEMPESTA
+	{
+		struct crypto_alg *alg =
+			cryptd_find_alg_cached(cryptd_alg_name, type, mask,
+					       crypto_find_ahash,
+					       &ahash_alg_cache);
+		if (IS_ERR(alg))
+			return (struct cryptd_ahash *)alg;
+
+		tfm = crypto_alloc_ahash_atomic(alg);
+	}
+#else
 	tfm = crypto_alloc_ahash(cryptd_alg_name, type, mask);
 #endif
 	if (IS_ERR(tfm))
@@ -1360,26 +1424,23 @@ struct cryptd_aead *cryptd_alloc_aead(const char *alg_name,
 	char cryptd_alg_name[CRYPTO_MAX_ALG_NAME];
 	struct cryptd_aead_ctx *ctx;
 	struct crypto_aead *tfm;
-#ifdef CONFIG_SECURITY_TEMPESTA
-	static struct crypto_alg *alg = NULL;
 
-	if (unlikely(!alg)) {
-		WARN_ON_ONCE(in_serving_softirq());
-		if (snprintf(cryptd_alg_name, CRYPTO_MAX_ALG_NAME, "cryptd(%s)",
-			     alg_name)
-		    >= CRYPTO_MAX_ALG_NAME)
-		{
-			return ERR_PTR(-EINVAL);
-		}
-		alg = crypto_find_aead(cryptd_alg_name, type, mask);
-		if (IS_ERR(alg))
-			return (struct cryptd_aead *)alg;
-	}
-	tfm = crypto_alloc_aead_atomic(alg);
-#else
 	if (snprintf(cryptd_alg_name, CRYPTO_MAX_ALG_NAME,
 		     "cryptd(%s)", alg_name) >= CRYPTO_MAX_ALG_NAME)
 		return ERR_PTR(-EINVAL);
+
+#ifdef CONFIG_SECURITY_TEMPESTA
+	{
+		struct crypto_alg *alg =
+			cryptd_find_alg_cached(cryptd_alg_name, type, mask,
+					       crypto_find_aead,
+					       &aead_alg_cache);
+		if (IS_ERR(alg))
+			return (struct cryptd_aead *)alg;
+
+		tfm = crypto_alloc_aead_atomic(alg);
+	}
+#else
 	tfm = crypto_alloc_aead(cryptd_alg_name, type, mask);
 #endif
 	if (IS_ERR(tfm))

--- a/crypto/shash.c
+++ b/crypto/shash.c
@@ -465,6 +465,8 @@ EXPORT_SYMBOL_GPL(crypto_find_shash);
 struct crypto_shash *
 crypto_alloc_shash_atomic(struct crypto_alg *alg)
 {
+	alg = crypto_mod_get(alg);
+	BUG_ON(!alg);
 	return crypto_create_tfm(alg, &crypto_shash_type);
 }
 EXPORT_SYMBOL_GPL(crypto_alloc_shash_atomic);

--- a/crypto/skcipher.c
+++ b/crypto/skcipher.c
@@ -939,6 +939,8 @@ EXPORT_SYMBOL_GPL(crypto_find_skcipher);
 struct crypto_skcipher *
 crypto_alloc_skcipher_atomic(struct crypto_alg *alg)
 {
+	alg = crypto_mod_get(alg);
+	BUG_ON(!alg);
 	return crypto_create_tfm(alg, &crypto_skcipher_type2);
 }
 EXPORT_SYMBOL_GPL(crypto_alloc_skcipher_atomic);


### PR DESCRIPTION
All of `cryptd_alloc_skcipher()`, `cryptd_alloc_ahash()`, and `cryptd_alloc_aead()` can be asked for various algorithms. Cache not only one, but every newly requested algorithm. Increase reference count each time to prevent modules unloading when transforms are freed.

The cache have no retention policy, that's the expected behavior for now.