### PR TITLE
We can not call tcp_reset(), which purges the TCP write queue, and just

### DIFF
--- a/net/core/sock.c
+++ b/net/core/sock.c
@@ -1806,16 +1806,8 @@ void sock_wfree(struct sk_buff *skb)
 	 * if sk_wmem_alloc reaches 0, we must finish what sk_free()
 	 * could not do because of in-flight packets
 	 */
-	if (refcount_sub_and_test(len, &sk->sk_wmem_alloc)) {
-		/*
-		 * We don't bother with Tempesta socket memory limitations
-		 * since in proxy mode we just forward packets instead of real
-		 * allocations. Probably this is an issue. Probably sockets
-		 * can be freed from under us.
-		 */
-		WARN_ON(sock_flag(sk, SOCK_TEMPESTA));
+	if (refcount_sub_and_test(len, &sk->sk_wmem_alloc))
 		__sk_free(sk);
-	}
 }
 EXPORT_SYMBOL(sock_wfree);
 

--- a/net/ipv4/tcp_output.c
+++ b/net/ipv4/tcp_output.c
@@ -2396,37 +2396,9 @@ static bool tcp_write_xmit(struct sock *sk, unsigned int mss_now, int nonagle,
 		 */
 		if (sk->sk_write_xmit && tempesta_tls_skb_type(skb)) {
 			result = sk->sk_write_xmit(sk, skb, limit);
-			if (result == -EPIPE) {
-				/* Just a closed socket - do nothing. */
-				WARN_ON_ONCE(!sock_flag(sk, SOCK_DEAD));
-				return false;
-			}
-			if (result) {
-				/*
-				 * We can not send unencrypted data and can not
-				 * close and free the socket from here:
-				 * 1. our caller may reference the socket;
-				 * 2. and also we can not normally close the
-				 *    socket with FIN since we just drop the
-				 *    TCP payload (sender didn't finish
-				 *    transmission).
-				 * Move the socket to dead state and just drop
-				 * all the pending unencrypted data - hopefully
-				 * the someone closes it at some point, see
-				 * tcp_reset(). This should never happen.
-				 *
-				 * TODO send RST.
-				 */
-				net_warn_ratelimited(
-					"Tempesta TLS: cannot encrypt data (%d),"
-					" try to close the TCP connection.\n",
-					result);
-				tcp_write_queue_purge(sk);
-				tcp_clear_xmit_timers(sk);
-				sk->sk_err = ECONNRESET;
-				tcp_set_state(sk, TCP_CLOSE);
-				sk->sk_shutdown = SHUTDOWN_MASK;
-				sock_set_flag(sk, SOCK_DEAD);
+			if (unlikely(result)) {
+				if (result == -ENOMEM)
+					break; /* try again next time */
 				return false;
 			}
 			/* Fix up TSO segments after TLS overhead. */


### PR DESCRIPTION
break from the tcp_write_xmit() loop right into tcp_schedule_loss_probe()
using the queue.

Fix: if the call back is called under memory pressure, then we can
retry it next time, in all other cases just immediately return from
the tcp_write_xmit().

Additional cleanup: remove the misleading comment and warning that we
do not track socket memory.